### PR TITLE
XMLApiClient stops working after Silverpop response has no content

### DIFF
--- a/src/main/java/com/silverpop/api/client/ApiClient.java
+++ b/src/main/java/com/silverpop/api/client/ApiClient.java
@@ -53,7 +53,7 @@ public abstract class ApiClient<REQUEST extends ApiRequest> {
     }
 
 	private boolean retryCommand(ApiErrorResult errorResult) {
-		return errorResult.isSessionInvalidOrExpired() && getSession().isReAuthenticate();
+		return errorResult.isSessionLost() && getSession().isReAuthenticate();
 	}
 
 	private ApiResult validateSessionAndExecuteCommand(ApiCommand command, Map<String,String> requestHeaders) throws ApiResultException {

--- a/src/main/java/com/silverpop/api/client/ApiErrorResult.java
+++ b/src/main/java/com/silverpop/api/client/ApiErrorResult.java
@@ -2,6 +2,6 @@ package com.silverpop.api.client;
 
 public interface ApiErrorResult extends ApiResult {
 	String getMessage();
-	boolean isSessionInvalidOrExpired();
+	boolean isSessionLost();
 	String getResponseText();
 }

--- a/src/main/java/com/silverpop/api/client/xmlapi/NoResponseApiErrorResult.java
+++ b/src/main/java/com/silverpop/api/client/xmlapi/NoResponseApiErrorResult.java
@@ -14,7 +14,7 @@ public class NoResponseApiErrorResult implements ApiErrorResult {
     }
 
     @Override
-    public boolean isSessionInvalidOrExpired() {
+    public boolean isSessionLost() {
         return true;
     }
 

--- a/src/main/java/com/silverpop/api/client/xmlapi/XmlApiErrorResult.java
+++ b/src/main/java/com/silverpop/api/client/xmlapi/XmlApiErrorResult.java
@@ -30,7 +30,7 @@ public class XmlApiErrorResult implements ApiErrorResult {
 	}
 
 	@Override
-	public boolean isSessionInvalidOrExpired() {
+	public boolean isSessionLost() {
 		return getDetail().getError().getErrorId() == 145 &&  "SP.Admin".equals(getDetail().getError().getErrorClass());
 	}
 


### PR DESCRIPTION
After using the same instance of XMLApiClient for a while, we often saw some ApiException in the logs, because the response had no content (but the HTTP-Status Code was 200).
We believe that the session was expired or otherwise invalid, but the XMLApiClient did not recover from this state.

This should now be fixed, because in case of an empty content the session will now be restored and the command repeated. Therefore we need to throw a different Exception with a specia ErrorResult.

Besides this Pull-request:

Maybe you can also explain the goals of this project:
- Are you guys from Silverpop? Is the some kind of offical Java-API for Silverpop?
- Do you have a timeline when this will be production ready?
- Are you going to publish it to Maven Central?
- Can we upgrade to Java7 or are you stuck to Java6 for some reason?
