### PR TITLE
Update XStreamAlias case to match what's expected by XMLAPI

### DIFF
--- a/src/main/java/com/silverpop/api/client/mailing/command/SaveMailingHeader.java
+++ b/src/main/java/com/silverpop/api/client/mailing/command/SaveMailingHeader.java
@@ -5,7 +5,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 //<Subject>Subject of a Mailing</Subject><TrackingLevel>4</TrackingLevel><Encoding>6</Encoding><ListID>1924132</ListID> <EditorType>1</EditorType></Header>
 public class SaveMailingHeader {
 
-	@XStreamAlias("MailingId")
+	@XStreamAlias("MailingID")
 	private Long mailingId;
 
 	@XStreamAlias("MailingName")


### PR DESCRIPTION
The XMLAPI expects the mailing id header to be named MailingID instead of MailingId.
The type mismatch causes us to be able to create a new mailing using the library but not update an existing mailing.